### PR TITLE
Allowed expanded selections, refactored code (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "engines": {
     "atom": ">=0.174.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "postcss": "^5.0.12",
+    "postcss-pxtorem": "^3.1.0"
+  }
 }


### PR DESCRIPTION
Hey again Gustavo.

I ran into a problem where something wouldn't work (#7) and I got thinking that surely someone has already made a Node px to rem convertor and solved all these complex problems. We may as well not reinvent the wheel, and it benefits everyone for these solutions to be more cohesive.

So I found [postcss-pxtorem](https://github.com/cuth/postcss-pxtorem) and implemented it here. The awesome thing is, not only does it solve my problem with decimal points, it also lets you select the entire document, or any part of the document, as long as it's valid CSS.

The only problem is, the input for this library _has_ to be valid CSS. Sending something like `20px` will give an error. It needs to be something like `font-size: 20px;`. So I hacked it here, by adding fake CSS around a selection if the processing fails the first time.

This PR it 100% fully functional, but it's kind of dirty. I think at the very least we need to get rid of the nested try-catch before shipping this. The hack should only be applied if a regex detects that the selection is only a number followed by `px`, then otherwise it should be processed by postcss-pxtorem.

Ideally we would take it a step further and have a more elegant solution. Maybe we fork the postcss-pxtorem repo to expose their internal mechanism for converting px to rem and use it here. Or find another Node module that works just as well (doesn't like like one does, though).

Make sure to run `npm install` after cloning this branch as I've added dependencies.
